### PR TITLE
Create empty Rutherford output

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,8 @@ Install dependencies with `pip install pandas numpy matplotlib psutil pyyaml`.
 
    Output files include `dssd_non_vetoed_events.pkl`, `ppac_events.pkl`,
    `rutherford_events.pkl`, a merged event pickle and processing logs. If no
-   PPAC hits are present, `ppac_events.pkl` is not created.
+   PPAC hits are present, `ppac_events.pkl` is not created. The Rutherford
+   events file is always produced (it will be empty if no hits occurred).
 
 3. **Configure correlations**
 

--- a/shrec_utils.py
+++ b/shrec_utils.py
@@ -313,22 +313,27 @@ def extract_rutherford_data(raw_df):
         
         # Combine all Rutherford data
         ruth_data = pd.concat([ruthE, ruthW], ignore_index=True)
-        
-        # Convert timetag to seconds
+
+        cols = ['t', 'energy', 'board', 'channel', 'detector', 'timetag', 'nfile']
+
+        # Convert timetag to seconds if any data are present
         if len(ruth_data) > 0:
             ruth_data['t'] = np.round(ruth_data['timetag'] * TO_S, 6)
-            
+
             # Sort by time
             ruth_data = ruth_data.sort_values(by='t').reset_index(drop=True)
-            
+
             # Select columns for output
-            ruth_data = ruth_data[['t', 'energy', 'board', 'channel', 'detector', 'timetag', 'nfile']]
-            
+            ruth_data = ruth_data[cols]
+        else:
+            ruth_data = pd.DataFrame(columns=cols)
+
         return ruth_data
         
     except Exception as e:
         print(f"Error extracting Rutherford data: {str(e)}")
-        return pd.DataFrame()
+        cols = ['t', 'energy', 'board', 'channel', 'detector', 'timetag', 'nfile']
+        return pd.DataFrame(columns=cols)
 
 def detmerge(dssd_events, veto_events, time_window=400000e-12):
     """

--- a/sort_and_cal.py
+++ b/sort_and_cal.py
@@ -587,6 +587,8 @@ def extract_ancillary_data_chunked(csv_file, chunksize=50000, max_memory_mb=None
 def write_dataframe_to_pickle(df, output_path):
     """Append DataFrame to a pickle file."""
     if len(df) == 0:
+        if not os.path.exists(output_path):
+            df.to_pickle(output_path)
         return 0
     if os.path.exists(output_path):
         existing = pd.read_pickle(output_path)
@@ -699,11 +701,11 @@ def process_file(csv_file, output_paths, shrec_map_path, calibration_path,
             del ppac_data
             gc.collect()
 
-        if len(ruth_data) > 0:
-            write_dataframe_to_pickle(ruth_data, output_paths['rutherford'])
-            # Free memory immediately
-            del ruth_data
-            gc.collect()
+        # Always write Rutherford data so that downstream steps can rely on the file
+        write_dataframe_to_pickle(ruth_data, output_paths['rutherford'])
+        # Free memory immediately
+        del ruth_data
+        gc.collect()
         
         # 6. Free memory for remaining large objects
         if 'veto_events' in locals():


### PR DESCRIPTION
## Summary
- ensure rutherford pickle is written even when empty
- return an empty dataframe from `extract_rutherford_data` on no hits
- document that `rutherford_events.pkl` is always generated

## Testing
- `python -m py_compile sort_and_cal.py shrec_utils.py build_correlations.py run_correlations_from_list.py memory_utils.py time_units.py`

------
https://chatgpt.com/codex/tasks/task_e_686103c7161c8331b30ed0b6745dffb6